### PR TITLE
Upgrade to Kafka 1.1.0 / Confluent Platform 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,14 +14,16 @@ version = '1.4.0-SNAPSHOT'
 group = 'me.frmr.kafka.connect'
 
 dependencies {
-  compileOnly 'org.apache.kafka:connect-api:1.0.0'
+  compileOnly 'org.apache.kafka:connect-api:1.1.0'
+  compileOnly 'io.confluent:kafka-connect-avro-converter:4.1.0'
   compileOnly 'org.slf4j:slf4j-api:1.7.25'
-  compileOnly 'io.confluent:kafka-connect-avro-converter:4.0.0'
+
+  testCompile 'org.apache.kafka:connect-api:1.1.0'
+  testCompile 'io.confluent:kafka-connect-avro-converter:4.1.0'
+
 
   testCompile 'org.apache.commons:commons-io:1.3.2'
-  testCompile 'org.apache.kafka:connect-api:1.0.0'
   testCompile 'org.slf4j:slf4j-api:1.7.25'
-  testCompile 'io.confluent:kafka-connect-avro-converter:4.0.0'
   testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
   testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
 }


### PR DESCRIPTION
Upgrade to the latest version of Confluent Platform, 4.1.0.