### PR TITLE
Upgrade to Confluent Platform 4.1.3 / Kafka 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,19 +13,29 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 version = '1.4.0-SNAPSHOT'
 group = 'me.frmr.kafka.connect'
 
+ext {
+  // You have to keep these synced - so confluent 4.1.0 builds against kafka connect 1.1.0.
+  // You'll need to read the release notes for each confluent platform release to figure out
+  // what version of Kafka it's built against
+  kafkaVersion = '1.1.0'
+  cpVersion = '4.1.0'
+
+  junitVersion = '5.1.0'
+  slf4jApiVersion = '1.7.25'
+}
+
 dependencies {
-  compileOnly 'org.apache.kafka:connect-api:1.1.0'
-  compileOnly 'io.confluent:kafka-connect-avro-converter:4.1.0'
-  compileOnly 'org.slf4j:slf4j-api:1.7.25'
+  compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
+  compileOnly "io.confluent:kafka-connect-avro-converter:$cpVersion"
+  compileOnly "org.slf4j:slf4j-api:$slf4jApiVersion"
 
-  testCompile 'org.apache.kafka:connect-api:1.1.0'
-  testCompile 'io.confluent:kafka-connect-avro-converter:4.1.0'
-
+  testCompile "org.apache.kafka:connect-api:$kafkaVersion"
+  testCompile "io.confluent:kafka-connect-avro-converter:$cpVersion"
 
   testCompile 'org.apache.commons:commons-io:1.3.2'
-  testCompile 'org.slf4j:slf4j-api:1.7.25'
-  testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
-  testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+  testCompile "org.slf4j:slf4j-api:$slf4jApiVersion"
+  testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+  testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ ext {
   // You have to keep these synced - so confluent 4.1.0 builds against kafka connect 1.1.0.
   // You'll need to read the release notes for each confluent platform release to figure out
   // what version of Kafka it's built against
-  kafkaVersion = '1.1.0'
-  cpVersion = '4.1.0'
+  kafkaVersion = '1.1.1'
+  cpVersion = '4.1.3'
 
   junitVersion = '5.1.0'
   slf4jApiVersion = '1.7.25'


### PR DESCRIPTION
This version bumps the library to Confluent Platform 4.1.3 and Kafka 1.1.1