### PR TITLE
Bump to confluent platform 5.0.3 / kafka 2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ ext {
   // You have to keep these synced - so confluent 4.1.0 builds against kafka connect 1.1.0.
   // You'll need to read the release notes for each confluent platform release to figure out
   // what version of Kafka it's built against
-  kafkaVersion = '1.1.1'
-  cpVersion = '4.1.3'
+  kafkaVersion = '2.0.1'
+  cpVersion = '5.0.3'
 
   junitVersion = '5.1.0'
   slf4jApiVersion = '1.7.25'


### PR DESCRIPTION
This bumps the library to Confluent Platform 5.0.3 / Kafka 2.0.1